### PR TITLE
Fix ReferenceError: destDir is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var walkSync = require('walk-sync');
 var convert = require('convert-source-map');
 var CachingWriter = require('broccoli-caching-writer');
 
-function _genMkdirOrProcess(process) {
+function _genMkdirOrProcess(destDir, process) {
 	return function(relativePath) {
 		if (relativePath.slice(-1) === '/') {
 			return mkdirp.sync(path.join(destDir, relativePath));
@@ -28,7 +28,7 @@ function SourceMapInliner(inputTree) {
 SourceMapInliner.prototype = Object.create(CachingWriter.prototype);
 SourceMapInliner.prototype.constructor = SourceMapInliner;
 SourceMapInliner.prototype.updateCache = function(srcDir, destDir) {
-	walkSync(srcDir).forEach(_genMkdirOrProcess(function(relativePath) {
+	walkSync(srcDir).forEach(_genMkdirOrProcess(destDir, function(relativePath) {
 		if (_isSourceMappableFile(relativePath)) {
 			var srcPath = path.join(srcDir, relativePath);
 			var destPath = path.join(destDir, relativePath);
@@ -60,7 +60,7 @@ function SourceMapExtractor(inputTree) {
 SourceMapExtractor.prototype = Object.create(CachingWriter.prototype);
 SourceMapExtractor.prototype.constructor = SourceMapExtractor;
 SourceMapExtractor.prototype.updateCache = function(srcDir, destDir) {
-	walkSync(srcDir).forEach(_genMkdirOrProcess(function(relativePath) {
+	walkSync(srcDir).forEach(_genMkdirOrProcess(destDir, function(relativePath) {
 		if (_isSourceMappableFile(relativePath)) {
 			var srcPath = path.join(srcDir, relativePath);
 			var destPath = path.join(destDir, relativePath);


### PR DESCRIPTION
I've tried to use the plugin today and stumbled upon the fact it throws a ReferenceError:

```
[broccoli-debug] [AssetRewrite tree] ReferenceError: destDir is not defined
ReferenceError: destDir is not defined
  at .../node_modules/broccoli-source-map/index.js:12:33
  at Array.forEach (native)
  at SourceMapInliner.updateCache (.../node_modules/broccoli-source-map/index.js:31:19)
...
```

The PR fixes this. Hope this helps.
