### PR TITLE
Add support for .css/.js files not in the root of the source tree.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ SourceMapInliner.prototype.updateCache = function(srcDir, destDir) {
 			var srcPath = path.join(srcDir, relativePath);
 			var destPath = path.join(destDir, relativePath);
 			var srcCode = fs.readFileSync(srcPath, {encoding: 'utf-8'});
-			var smap = convert.fromMapFileSource(srcCode, srcDir);
+			var smap = convert.fromMapFileSource(srcCode, path.dirname(srcPath));
 			if (smap !== null && typeof smap['sourcemap'] !== 'undefined') {
 				if (typeof smap.getProperty('sourcesContent') === 'undefined' && typeof smap.getProperty('sources') !== 'undefined') {
 					var contents = smap.getProperty('sources').map(function(spath) {
@@ -65,7 +65,7 @@ SourceMapExtractor.prototype.updateCache = function(srcDir, destDir) {
 			var srcPath = path.join(srcDir, relativePath);
 			var destPath = path.join(destDir, relativePath);
 			var srcCode = fs.readFileSync(srcPath, {encoding: 'utf-8'});
-			var smap = convert.fromComment(srcCode, srcDir);
+			var smap = convert.fromComment(srcCode, path.dirname(srcPath));
 			if (smap !== null) {
 				var comment = '//# sourceMappingURL=' + relativePath + '.map';
 				if (destPath.slice(-4) === '.css') {


### PR DESCRIPTION
When the js/css files are located inside a subfolder in the source tree folder, the 2nd param sent to the convert module calls should point to the subfolder and not the source tree folder itself. Otherwise, convert can't find the source files and bails out with errors like:

`Error: ENOENT, no such file or directory '.../tmp/caching-writer-dest-dir_0hegfH.tmp/app.css.map'`

The PR fixes this.
