### PR TITLE
paths should be relative to their containing file

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ var SourceMapExtractor = SourceMapProcessor.extend({
 	processCode: function(srcCode, srcDir, destPath, relativePath) {
 		var smap = convert.fromComment(srcCode, srcDir);
 		if (smap !== null) {
-			var comment = '//# sourceMappingURL=' + relativePath + '.map';
+			var comment = '//# sourceMappingURL=' + path.basename(relativePath) + '.map';
 			if (destPath.slice(-4) === '.css') {
-				comment = '/*# sourceMappingURL=' + relativePath + '.map */';
+				comment = '/*# sourceMappingURL=' + path.basename(relativePath) + '.map */';
 			}
 			fs.writeFileSync(destPath, convert.removeComments(srcCode) + '\n' + comment);
 			fs.writeFileSync(destPath + '.map', smap.toJSON());


### PR DESCRIPTION
Problems become apparent when dealing with nested directors. E.g. /src/a/b.js

With the existing behavior, the source map would be inlined pointing to a/b.js.map, but that is incorrect since the path should be relative to the file: it should just be b.js.map
